### PR TITLE
HIPP-199: remove identity action to skip auth

### DIFF
--- a/app/config/Module.scala
+++ b/app/config/Module.scala
@@ -28,9 +28,6 @@ class Module extends AbstractModule {
     bind(classOf[DataRetrievalAction]).to(classOf[DataRetrievalActionImpl]).asEagerSingleton()
     bind(classOf[DataRequiredAction]).to(classOf[DataRequiredActionImpl]).asEagerSingleton()
 
-    // For session based storage instead of cred based, change to SessionIdentifierAction
-    bind(classOf[IdentifierAction]).to(classOf[AuthenticatedIdentifierAction]).asEagerSingleton()
-
     bind(classOf[Clock]).toInstance(Clock.systemDefaultZone.withZone(ZoneOffset.UTC))
   }
 }

--- a/app/controllers/IndexController.scala
+++ b/app/controllers/IndexController.scala
@@ -16,20 +16,19 @@
 
 package controllers
 
-import controllers.actions.IdentifierAction
-import javax.inject.Inject
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.IndexView
 
+import javax.inject.Inject
+
 class IndexController @Inject()(
                                  val controllerComponents: MessagesControllerComponents,
-                                 identify: IdentifierAction,
                                  view: IndexView
                                ) extends FrontendBaseController with I18nSupport {
 
-  def onPageLoad: Action[AnyContent] = identify { implicit request =>
+  def onPageLoad: Action[AnyContent] = Action { implicit request =>
     Ok(view())
   }
 }


### PR DESCRIPTION
This is not the entire ticket, but if merged now will unblock other tickets in progress (hence the name of the branch isn't reflective of the work in the PR). 

There's lots of unused code (more than just `IdentifierAction.scala`), but I'm tempted to leave everything as is until we complete the login work incase it's useful - then do a tidy up PR. 

2 more PRs to follow: 

1. add the login link to the landing page
2. remove unused import warnings in tests