### PR TITLE
HIPP-289: Stride stub in local environment - Port error

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -110,7 +110,7 @@ mongodb {
 
 urls {
   login         = "http://localhost:9949/auth-login-stub/gg-sign-in"
-  loginContinue = "http://localhost:9000/api-hub"
+  loginContinue = "http://localhost:"${play.server.http.port}"/api-hub"
   signOut       = "http://localhost:9025/gg/sign-out"
 }
 


### PR DESCRIPTION
https://jira.tools.tax.service.gov.uk/browse/HIPP-289

This should make the login continue URL use whatever is the current port. Won't really know until this is merged and tested using Service Manager.