### PR TITLE
HIPP-515: primary and secondary tabs

### DIFF
--- a/app/config/EnvironmentNames.scala
+++ b/app/config/EnvironmentNames.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import play.api.{ConfigLoader, Configuration}
+
+case class EnvironmentNames(primary: String, secondary: String)
+
+object EnvironmentNames {
+
+  implicit lazy val configLoader: ConfigLoader[EnvironmentNames] = ConfigLoader {
+    config =>
+      prefix =>
+
+        val service  = Configuration(config).get[Configuration](prefix)
+        val primary     = service.get[String]("primary")
+        val secondary     = service.get[String]("secondary")
+
+        EnvironmentNames(primary, secondary)
+  }
+}

--- a/app/config/EnvironmentNames.scala
+++ b/app/config/EnvironmentNames.scala
@@ -25,11 +25,9 @@ object EnvironmentNames {
   implicit lazy val configLoader: ConfigLoader[EnvironmentNames] = ConfigLoader {
     config =>
       prefix =>
-
         val service  = Configuration(config).get[Configuration](prefix)
         val primary     = service.get[String]("primary")
         val secondary     = service.get[String]("secondary")
-
         EnvironmentNames(primary, secondary)
   }
 }

--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -40,6 +40,8 @@ class FrontendAppConfig @Inject() (configuration: Configuration) {
   val signOutUrl: String         = configuration.get[String]("urls.signOut")
   val appAuthToken: String       = configuration.get[String]("internal-auth.token")
 
+  val environmentNames: EnvironmentNames = configuration.get[EnvironmentNames]("environment-names")
+
   private val exitSurveyBaseUrl: String = configuration.get[Service]("microservice.services.feedback-frontend").baseUrl
   val exitSurveyUrl: String             = s"$exitSurveyBaseUrl/feedback/api-hub-frontend"
 

--- a/app/controllers/ApplicationDetailsController.scala
+++ b/app/controllers/ApplicationDetailsController.scala
@@ -16,6 +16,7 @@
 
 package controllers
 
+import config.FrontendAppConfig
 import controllers.actions._
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -30,11 +31,12 @@ class ApplicationDetailsController @Inject()(
   identify: IdentifierAction,
   val controllerComponents: MessagesControllerComponents,
   view: ApplicationDetailsView,
-  applicationAuth: ApplicationAuthActionProvider
+  applicationAuth: ApplicationAuthActionProvider,
+  config: FrontendAppConfig
 ) (implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
 
   def onPageLoad(id: String): Action[AnyContent] = (identify andThen applicationAuth(id)) {
-    implicit request => Ok(view(request.application, Some(request.identifierRequest.user)))
+    implicit request => Ok(view(request.application, Some(request.identifierRequest.user), config.environmentNames))
   }
 
 }

--- a/app/views/ApplicationDetailsView.scala.html
+++ b/app/views/ApplicationDetailsView.scala.html
@@ -16,6 +16,7 @@
 
 @import models.application._
 @import models.user.UserModel
+@import config.EnvironmentNames
 @import views.ViewUtils
 
 @this(
@@ -25,7 +26,7 @@
         govukTable: GovukTable
 )
 
-@(application: Application, user: Option[UserModel])(implicit request: Request[_], messages: Messages)
+@(application: Application, user: Option[UserModel], environmentNames: EnvironmentNames)(implicit request: Request[_], messages: Messages)
 
 @applicationDetail(descriptionKey: String, value: String) = {
     <div class="govuk-grid-row">
@@ -45,7 +46,7 @@
 @environmentTab(name: String, environment: Environment) = @{
     TabItem(
         id = Some(name),
-        label = messages(s"applicationDetails.$name"),
+        label = name,
         panel = TabPanel(
             content = HtmlContent(environmentTabContent(environment))
         )
@@ -141,10 +142,8 @@
     @govukTabs(
         Tabs(
             items = Seq(
-                environmentTab("dev", application.environments.dev),
-                environmentTab("test", application.environments.test),
-                environmentTab("preProd", application.environments.preProd),
-                environmentTab("prod", application.environments.prod)
+                environmentTab(environmentNames.secondary, application.environments.secondary),
+                environmentTab(environmentNames.primary, application.environments.primary),
             )
         )
     )

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -121,6 +121,11 @@ urls {
   signOut         = "http://localhost:9025/gg/sign-out"
 }
 
+environment-names {
+  secondary = "secondary"
+  primary = "primary"
+}
+
 host = "http://localhost:9000"
 
 accessibility-statement{

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -23,7 +23,7 @@ import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.{OptionValues, TryValues}
-import play.api.Application
+import play.api.{Application, Configuration}
 import play.api.i18n.{Messages, MessagesApi}
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
@@ -43,8 +43,10 @@ trait SpecBase
 
   def messages(app: Application): Messages = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
 
-  protected def applicationBuilder(userAnswers: Option[UserAnswers] = None, user: UserModel = FakeUser): GuiceApplicationBuilder =
-    new GuiceApplicationBuilder()
+  protected def applicationBuilder(userAnswers: Option[UserAnswers] = None,
+                                   user: UserModel = FakeUser,
+                                   testConfiguration: Configuration = Configuration.empty): GuiceApplicationBuilder =
+    GuiceApplicationBuilder(configuration = testConfiguration)
       .overrides(
         bind[UserModel].toInstance(user),
         bind[DataRequiredAction].to[DataRequiredActionImpl],

--- a/test/config/EnvironmentNamesSpec.scala
+++ b/test/config/EnvironmentNamesSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import org.mockito.MockitoSugar
+import org.scalatest.freespec.AsyncFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import play.api.Configuration
+
+class EnvironmentNamesSpec extends AsyncFreeSpec with Matchers with MockitoSugar {
+
+  "EnvironmentNames" - {
+    "must be loaded from config properly" in {
+      val primaryEnvName = "primaryEnvName"
+      val secondaryEnvName = "secondaryEnvName"
+
+      val mockConfiguration = Configuration.from(Map(
+        "environment-names.primary" -> primaryEnvName,
+        "environment-names.secondary" -> secondaryEnvName
+      ))
+
+      val envNames = mockConfiguration.get[EnvironmentNames]("environment-names")
+
+      envNames shouldBe EnvironmentNames(primaryEnvName, secondaryEnvName)
+    }
+  }
+}


### PR DESCRIPTION
I found it was not possible to have variable strings in the messages file.

I considered using the config files for QA and Prod (because those names don't change regardless of language) and using the messages file for other environments (because "primary" and "secondary" can be translated). 

However, I felt that the complexity this would bring isn't worth it considering:
* our users will only ever visit the hub on Prod
* we don't intend to swap languages using the languages file