### PR TITLE
HIPP-917: Modify Select Endpoints Page

### DIFF
--- a/app/controllers/AddAnApiSelectEndpointsController.scala
+++ b/app/controllers/AddAnApiSelectEndpointsController.scala
@@ -24,7 +24,6 @@ import models.requests.DataRequest
 import models.{AddAnApiContext, AvailableEndpoints, Mode}
 import navigation.Navigator
 import pages.{AddAnApiApiPage, AddAnApiSelectApplicationPage, AddAnApiSelectEndpointsPage}
-import play.api.Logging
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc._
 import repositories.AddAnApiSessionRepository
@@ -45,7 +44,7 @@ class AddAnApiSelectEndpointsController @Inject()(
   val controllerComponents: MessagesControllerComponents,
   view: AddAnApiSelectEndpointsView,
   checkContext: AddAnApiCheckContextActionProvider
-)(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport with Logging {
+)(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
 
   def onPageLoad(
     mode: Mode,
@@ -97,7 +96,7 @@ class AddAnApiSelectEndpointsController @Inject()(
         .toSeq
         .zipWithIndex
         .filter(_._1._2.exists(_.added))
-        .map(etc => s"value[${etc._2}]" -> Seq(etc._1._1.toString()))
+        .map(data => s"value[${data._2}]" -> Seq(data._1._1.toString()))
         .toMap
 
   }

--- a/app/controllers/AddAnApiStartController.scala
+++ b/app/controllers/AddAnApiStartController.scala
@@ -16,14 +16,15 @@
 
 package controllers
 
-import controllers.actions.IdentifierAction
+import controllers.actions.{ApplicationAuthActionProvider, IdentifierAction}
 import controllers.helpers.ErrorResultBuilder
+import models.api.ApiDetail
 import models.requests.IdentifierRequest
-import models.{AddAnApi, AddAnApiContext, AddEndpoints, NormalMode, UserAnswers}
+import models.{AddAnApi, AddAnApiContext, AddEndpoints, AvailableEndpoints, NormalMode, UserAnswers}
 import navigation.Navigator
-import pages.{AddAnApiApiIdPage, AddAnApiContextPage, AddAnApiSelectApplicationPage}
+import pages.{AddAnApiApiPage, AddAnApiContextPage, AddAnApiSelectApplicationPage, AddAnApiSelectEndpointsPage}
 import play.api.i18n.{I18nSupport, Messages}
-import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import play.api.mvc._
 import repositories.AddAnApiSessionRepository
 import services.ApiHubService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
@@ -40,39 +41,56 @@ class AddAnApiStartController @Inject()(
   addAnApiSessionRepository: AddAnApiSessionRepository,
   clock: Clock,
   navigator: Navigator,
-  errorResultBuilder: ErrorResultBuilder
+  errorResultBuilder: ErrorResultBuilder,
+  applicationAuth: ApplicationAuthActionProvider
 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
 
   def addAnApi(apiId: String): Action[AnyContent] = identify.async {
     implicit request =>
-      startJourney(apiId, commonUserAnswers(apiId, AddAnApi))
+      fetchApiDetail(apiId).flatMap {
+        case Right(apiDetail) =>
+          startJourney(apiId, commonUserAnswers(apiDetail, AddAnApi, request))
+        case Left(result) => Future.successful(result)
+      }
   }
 
-  def addEndpoints(applicationId: String, apiId: String): Action[AnyContent] = identify.async {
+  def addEndpoints(applicationId: String, apiId: String): Action[AnyContent] = (identify andThen applicationAuth(applicationId)).async {
     implicit request =>
-      startJourney(
-        apiId,
-        commonUserAnswers(apiId, AddEndpoints)
-          .flatMap(_.set(AddAnApiSelectApplicationPage, applicationId))
-      )
+      fetchApiDetail(apiId).flatMap {
+        case Right(apiDetail) =>
+          startJourney(
+            apiId,
+            commonUserAnswers(apiDetail, AddEndpoints, request.identifierRequest)
+              .flatMap(_.set(AddAnApiSelectApplicationPage, request.application))
+              .flatMap(_.set(AddAnApiSelectEndpointsPage, AvailableEndpoints.addedScopes(apiDetail, request.application)))
+          )
+        case Left(result) => Future.successful(result)
+      }
   }
 
-  private def commonUserAnswers(apiId: String, context: AddAnApiContext)(implicit request: IdentifierRequest[_]): Try[UserAnswers] = {
+  private def fetchApiDetail(apiId: String)(implicit request: Request[_]): Future[Either[Result, ApiDetail]] = {
+    apiHubService.getApiDetail(apiId).map {
+      case Some(apiDetail) => Right(apiDetail)
+      case _ => Left(apiNotFound(apiId))
+    }
+  }
+
+  private def commonUserAnswers(apiDetail: ApiDetail, context: AddAnApiContext, request: IdentifierRequest[_]): Try[UserAnswers] = {
     UserAnswers(
       id = request.user.userId,
       lastUpdated = clock.instant()
     )
-      .set(AddAnApiApiIdPage, apiId)
+      .set(AddAnApiApiPage, apiDetail)
       .flatMap(_.set(AddAnApiContextPage, context))
   }
 
-  private def startJourney(id: String, userAnswers: Try[UserAnswers])(implicit request: IdentifierRequest[_]) = {
+  private def startJourney(id: String, userAnswers: Try[UserAnswers])(implicit request: Request[_]) = {
     apiHubService.getApiDetail(id).flatMap {
       case Some(_) =>
         for {
           userAnswers <- Future.fromTry(userAnswers)
           _           <- addAnApiSessionRepository.set(userAnswers)
-        } yield Redirect(navigator.nextPage(AddAnApiApiIdPage, NormalMode, userAnswers))
+        } yield Redirect(navigator.nextPage(AddAnApiApiPage, NormalMode, userAnswers))
       case None =>
         Future.successful(
           errorResultBuilder.notFound(
@@ -81,6 +99,13 @@ class AddAnApiStartController @Inject()(
           )
         )
     }
+  }
+
+  private def apiNotFound(apiId: String)(implicit request: Request[_]): Result = {
+    errorResultBuilder.notFound(
+      Messages("site.apiNotFound.heading"),
+      Messages("site.apiNotFound.message", apiId)
+    )
   }
 
 }

--- a/app/controllers/AddAnApiStartController.scala
+++ b/app/controllers/AddAnApiStartController.scala
@@ -49,7 +49,7 @@ class AddAnApiStartController @Inject()(
     implicit request =>
       fetchApiDetail(apiId).flatMap {
         case Right(apiDetail) =>
-          startJourney(apiId, commonUserAnswers(apiDetail, AddAnApi, request))
+          startJourney(commonUserAnswers(apiDetail, AddAnApi, request))
         case Left(result) => Future.successful(result)
       }
   }
@@ -59,7 +59,6 @@ class AddAnApiStartController @Inject()(
       fetchApiDetail(apiId).flatMap {
         case Right(apiDetail) =>
           startJourney(
-            apiId,
             commonUserAnswers(apiDetail, AddEndpoints, request.identifierRequest)
               .flatMap(_.set(AddAnApiSelectApplicationPage, request.application))
               .flatMap(_.set(AddAnApiSelectEndpointsPage, AvailableEndpoints.addedScopes(apiDetail, request.application)))
@@ -84,21 +83,11 @@ class AddAnApiStartController @Inject()(
       .flatMap(_.set(AddAnApiContextPage, context))
   }
 
-  private def startJourney(id: String, userAnswers: Try[UserAnswers])(implicit request: Request[_]) = {
-    apiHubService.getApiDetail(id).flatMap {
-      case Some(_) =>
-        for {
-          userAnswers <- Future.fromTry(userAnswers)
-          _           <- addAnApiSessionRepository.set(userAnswers)
-        } yield Redirect(navigator.nextPage(AddAnApiApiPage, NormalMode, userAnswers))
-      case None =>
-        Future.successful(
-          errorResultBuilder.notFound(
-            Messages("site.apiNotFound.heading"),
-            Messages("site.apiNotFound.message", id)
-          )
-        )
-    }
+  private def startJourney(userAnswers: Try[UserAnswers]) = {
+    for {
+      userAnswers <- Future.fromTry(userAnswers)
+      _           <- addAnApiSessionRepository.set(userAnswers)
+    } yield Redirect(navigator.nextPage(AddAnApiApiPage, NormalMode, userAnswers))
   }
 
   private def apiNotFound(apiId: String)(implicit request: Request[_]): Result = {

--- a/app/controllers/ApiPolicyConditionsDeclarationPageController.scala
+++ b/app/controllers/ApiPolicyConditionsDeclarationPageController.scala
@@ -17,17 +17,15 @@
 package controllers
 
 import controllers.actions._
-import controllers.helpers.ErrorResultBuilder
 import forms.ApiPolicyConditionsDeclarationPageFormProvider
-import models.{AddAnApiContext, ApiPolicyConditionsDeclaration, Mode}
 import models.requests.DataRequest
+import models.{AddAnApiContext, ApiPolicyConditionsDeclaration, Mode}
 import navigation.Navigator
-import pages.{AddAnApiApiIdPage, ApiPolicyConditionsDeclarationPage}
+import pages.{AddAnApiApiPage, ApiPolicyConditionsDeclarationPage}
 import play.api.data.Form
-import play.api.i18n.{I18nSupport, Messages, MessagesApi}
-import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Request, Result}
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import repositories.AddAnApiSessionRepository
-import services.ApiHubService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.ApiPolicyConditionsDeclarationPageView
 
@@ -44,8 +42,6 @@ class ApiPolicyConditionsDeclarationPageController @Inject()(
   formProvider: ApiPolicyConditionsDeclarationPageFormProvider,
   val controllerComponents: MessagesControllerComponents,
   view: ApiPolicyConditionsDeclarationPageView,
-  apiHubService: ApiHubService,
-  errorResultBuilder: ErrorResultBuilder,
   checkContext: AddAnApiCheckContextActionProvider
 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
 
@@ -86,33 +82,19 @@ class ApiPolicyConditionsDeclarationPageController @Inject()(
     form: Form[Set[ApiPolicyConditionsDeclaration]],
     status: Status
   )(implicit request: DataRequest[AnyContent]):Future[Result] = {
-    request.userAnswers.get(AddAnApiApiIdPage) match {
-      case Some(apiId) =>
-        apiHubService.getApiDetail(apiId).flatMap {
-          case Some(apiDetail) =>
-            Future.successful(status(
-              view(
-                form,
-                mode,
-                context,
-                apiDetail
-              )
-            ))
-
-          case None => apiNotFound(apiId)
-      }
+    request.userAnswers.get(AddAnApiApiPage) match {
+      case Some(apiDetail) =>
+        Future.successful(status(
+          view(
+            form,
+            mode,
+            context,
+            apiDetail
+          )
+        ))
       case _ => Future.successful(Redirect(routes.JourneyRecoveryController.onPageLoad()))
 
     }
-  }
-
-  private def apiNotFound(apiId: String)(implicit request: Request[_]): Future[Result] = {
-    Future.successful(
-      errorResultBuilder.notFound(
-        Messages("site.apiNotFound.heading"),
-        Messages("site.apiNotFound.message", apiId)
-      )
-    )
   }
 
 }

--- a/app/forms/AddAnApiSelectEndpointsFormProvider.scala
+++ b/app/forms/AddAnApiSelectEndpointsFormProvider.scala
@@ -18,6 +18,7 @@ package forms
 
 import forms.mappings.Mappings
 import models.api.ApiDetail
+import models.application.Application
 import models.{AvailableEndpoints, Enumerable}
 import play.api.data.Form
 import play.api.data.Forms.set
@@ -26,8 +27,8 @@ import javax.inject.Inject
 
 class AddAnApiSelectEndpointsFormProvider @Inject() extends Mappings {
 
-  def apply(apiDetail: ApiDetail): Form[Set[Set[String]]] = {
-    val availableEndpoints = AvailableEndpoints(apiDetail)
+  def apply(apiDetail: ApiDetail, application: Application): Form[Set[Set[String]]] = {
+    val availableEndpoints = AvailableEndpoints(apiDetail, application)
 
     implicit val enumerableScopes: Enumerable[Set[String]] = (str: String) => {
       availableEndpoints.keySet.find(_.toString() == str)

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -31,7 +31,7 @@ class Navigator @Inject()() {
     case QuestionAddTeamMembersPage => questionAddTeamMembersNextPage(NormalMode)
     case TeamMembersPage => _ => routes.ConfirmAddTeamMemberController.onPageLoad(NormalMode)
     case ConfirmAddTeamMemberPage => confirmAddTeamMemberNextPage(NormalMode)
-    case AddAnApiApiIdPage => addAnApiApiIdNextPage
+    case AddAnApiApiPage => addAnApiApiIdNextPage
     case AddAnApiSelectApplicationPage => addAnApiSelectApplicationNextPage(NormalMode)
     case AddAnApiSelectEndpointsPage => addAnApiSelectEndpointsNextPage(NormalMode)
     case ApiPolicyConditionsDeclarationPage => apiPolicyConditionsDeclarationNextPage(NormalMode)

--- a/app/pages/AddAnApiApiPage.scala
+++ b/app/pages/AddAnApiApiPage.scala
@@ -16,17 +16,13 @@
 
 package pages
 
-import pages.behaviours.PageBehaviours
+import models.api.ApiDetail
+import play.api.libs.json.JsPath
 
-class AddAnApiApiIdPageSpec extends PageBehaviours {
+case object AddAnApiApiPage extends QuestionPage[ApiDetail] {
 
-  "AddAnApiApiIdPage" - {
+  override def path: JsPath = JsPath \ toString
 
-    beRetrievable[String](AddAnApiApiIdPage)
-
-    beSettable[String](AddAnApiApiIdPage)
-
-    beRemovable[String](AddAnApiApiIdPage)
-  }
+  override def toString: String = "api"
 
 }

--- a/app/pages/AddAnApiSelectApplicationPage.scala
+++ b/app/pages/AddAnApiSelectApplicationPage.scala
@@ -16,12 +16,13 @@
 
 package pages
 
+import models.application.Application
 import play.api.libs.json.JsPath
 
-case object AddAnApiSelectApplicationPage extends QuestionPage[String] {
+case object AddAnApiSelectApplicationPage extends QuestionPage[Application] {
 
   override def path: JsPath = JsPath \ toString
 
-  override def toString: String = "applicationId"
+  override def toString: String = "application"
 
 }

--- a/app/viewmodels/checkAnswers/AddAnApiSelectEndpointsSummary.scala
+++ b/app/viewmodels/checkAnswers/AddAnApiSelectEndpointsSummary.scala
@@ -18,6 +18,7 @@ package viewmodels.checkAnswers
 
 import controllers.routes
 import models.api.ApiDetail
+import models.application.Application
 import models.{AddAnApiContext, AvailableEndpoint, AvailableEndpoints, CheckMode, UserAnswers}
 import pages.AddAnApiSelectEndpointsPage
 import play.api.i18n.Messages
@@ -28,11 +29,11 @@ import viewmodels.implicits._
 
 object AddAnApiSelectEndpointsSummary  {
 
-  def row(answers: UserAnswers, apiDetail: ApiDetail, context: AddAnApiContext)(implicit messages: Messages): Option[SummaryListRow] =
+  def row(answers: UserAnswers, apiDetail: ApiDetail, application: Application, context: AddAnApiContext)(implicit messages: Messages): Option[SummaryListRow] =
     answers.get(AddAnApiSelectEndpointsPage).map {
       answers =>
 
-        val endpoints = AvailableEndpoints.selectedEndpoints(apiDetail, answers)
+        val endpoints = AvailableEndpoints.selectedEndpoints(apiDetail, application, answers)
           .values
           .flatten
           .map(endpoint => s"<li>${httpMethod(endpoint)} ${endpoint.path}</li>")

--- a/app/views/AddAnApiSelectEndpointsView.scala.html
+++ b/app/views/AddAnApiSelectEndpointsView.scala.html
@@ -15,6 +15,7 @@
  *@
 
 @import models.{AvailableEndpoint, AddAnApiContext}
+@import models.application.Application
 @import models.api.ApiDetail
 @import models.user.UserModel
 
@@ -25,11 +26,17 @@
     govukButton: GovukButton
 )
 
-@(form: Form[Set[Set[String]]], mode: Mode, context: AddAnApiContext, user: Option[UserModel], apiDetail: ApiDetail)(implicit request: Request[_], messages: Messages)
+@(form: Form[Set[Set[String]]], mode: Mode, context: AddAnApiContext, user: Option[UserModel], apiDetail: ApiDetail, application: Application)(implicit request: Request[_], messages: Messages)
 
-@checked(value: Set[String]) = {
-    @if(form.value.getOrElse(Set.empty).contains(value)) {
+@checked(scopes: Set[String]) = {
+    @if(form.value.getOrElse(Set.empty).contains(scopes)) {
         checked
+    }
+}
+
+@readonly(endpoints: Seq[AvailableEndpoint]) = {
+    @if(endpoints.exists(_.added)) {
+        disabled
     }
 }
 
@@ -59,10 +66,10 @@
                 }
 
                 <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-                    @AvailableEndpoints(apiDetail).toSeq.zipWithIndex.map {case (value, index) =>
+                    @AvailableEndpoints(apiDetail, application).toSeq.zipWithIndex.map {case (value, index) =>
                     <div class="custom-checkbox-holder">
                         <div class="govuk-checkboxes__item govuk-!-margin-bottom-5">
-                            <input class="govuk-checkboxes__input" id="value_@index" name="value[@index]" type="checkbox" value="@(value._1.toString)" @checked(value._1)>
+                            <input class="govuk-checkboxes__input" id="value_@index" name="value[@index]" type="checkbox" value="@(value._1.toString)" @checked(value._1) @readonly(value._2)>
                             <label class="govuk-label govuk-checkboxes__label" for="value_@index">
                                 @if(value._2.size == 1) {
                                     @messages("addAnApiSelectEndpoints.selectEndpoint")

--- a/test-utils/generators/ApplicationGenerator.scala
+++ b/test-utils/generators/ApplicationGenerator.scala
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package generators
+
+import models.application._
+import org.scalacheck.{Arbitrary, Gen}
+
+import java.time.{Instant, LocalDateTime, ZoneId}
+
+trait ApplicationGenerator {
+
+  val appIdGenerator: Gen[String] = {
+    Gen.listOfN(24, Gen.hexChar).map(_.mkString.toLowerCase)
+  }
+
+  val localDateTimeGenerator: Gen[LocalDateTime] = {
+    for {
+      calendar <- Gen.calendar
+    } yield LocalDateTime.ofInstant(Instant.ofEpochMilli(calendar.getTimeInMillis), ZoneId.of("GMT"))
+  }
+
+  val emailGenerator: Gen[String] = {
+    for {
+      username <- Gen.alphaLowerStr
+      emailDomain <- Gen.oneOf(Seq("@hmrc.gov.uk", "@digital.hmrc.gov.uk"))
+    } yield s"$username$emailDomain"
+  }
+
+  val creatorGenerator: Gen[Creator] = {
+    for {
+      email <- emailGenerator
+    } yield Creator(email)
+  }
+
+  val teamMemberGenerator: Gen[TeamMember] = {
+    for {
+      email <- emailGenerator
+    } yield TeamMember(email)
+  }
+
+  val scopeGenerator: Gen[Scope] = {
+    for {
+      name <- Gen.alphaStr
+      status <- Gen.oneOf(ScopeStatus.values)
+    } yield Scope(name, status)
+  }
+
+  val credentialGenerator: Gen[Credential] = {
+    for {
+      clientId <- Gen.uuid
+      clientSecret <- Gen.uuid
+      created <- localDateTimeGenerator
+    } yield Credential(clientId.toString, created, Some(clientSecret.toString), Some(clientSecret.toString.takeRight(4)))
+  }
+
+  val environmentGenerator: Gen[Environment] = {
+    for {
+      scopes <- Gen.listOf(scopeGenerator)
+      credentials <- Gen.listOf(credentialGenerator)
+    } yield Environment(scopes, credentials)
+  }
+
+  val environmentsGenerator: Gen[Environments] = {
+    for {
+      primary <- environmentGenerator
+      secondary <- environmentGenerator
+    } yield Environments(primary,secondary)
+  }
+
+  implicit val applicationGenerator: Arbitrary[Application] = Arbitrary {
+    for {
+      appId <- appIdGenerator
+      name <- Gen.alphaStr
+      created <- localDateTimeGenerator
+      createdBy <- creatorGenerator
+      lastUpdated <- localDateTimeGenerator
+      teamMembers <- Gen.listOf(teamMemberGenerator)
+      environments <- environmentsGenerator
+    } yield
+    Application(
+      appId,
+      name,
+      created,
+      createdBy,
+      lastUpdated,
+      teamMembers,
+      environments,
+      Seq.empty
+    )
+  }
+
+  implicit val newApplicationGenerator: Arbitrary[NewApplication] =
+    Arbitrary {
+      for {
+        name <- Gen.alphaStr
+        createdBy <- creatorGenerator
+        teamMembers <- Gen.listOf(teamMemberGenerator)
+      } yield
+        NewApplication(
+          name,
+          createdBy,
+          teamMembers
+        )
+    }
+
+  val newScopeGenerator: Gen[NewScope] = {
+    for {
+      name <- Gen.alphaStr.suchThat(_.nonEmpty)
+      environments <- Gen.atLeastOne(EnvironmentName.values)
+    } yield NewScope(name, environments.toSeq)
+  }
+
+  implicit val newScopesGenerator: Arbitrary[Seq[NewScope]] =
+    Arbitrary {
+      Gen.listOf(newScopeGenerator)
+    }
+
+
+}

--- a/test/controllers/AddAnApiCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/AddAnApiCheckYourAnswersControllerSpec.scala
@@ -25,7 +25,7 @@ import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.mockito.MockitoSugar.mock
-import pages.{AddAnApiApiIdPage, AddAnApiContextPage, AddAnApiSelectApplicationPage, AddAnApiSelectEndpointsPage}
+import pages.{AddAnApiApiPage, AddAnApiContextPage, AddAnApiSelectApplicationPage, AddAnApiSelectEndpointsPage}
 import play.api.Application
 import play.api.inject.bind
 import play.api.test.FakeRequest
@@ -80,8 +80,8 @@ class AddAnApiCheckYourAnswersControllerSpec extends SpecBase with SummaryListFl
 
       val userAnswers = emptyUserAnswers
         .set(AddAnApiContextPage, AddAnApi).toOption.value
-        .set(AddAnApiApiIdPage, apiDetail.id).toOption.value
-        .set(AddAnApiSelectApplicationPage, FakeApplication.id).toOption.value
+        .set(AddAnApiApiPage, apiDetail).toOption.value
+        .set(AddAnApiSelectApplicationPage, FakeApplication).toOption.value
         .set(AddAnApiSelectEndpointsPage, Set(Set("test-scope-1"))).toOption.value
 
       val fixture = buildFixture(Some(userAnswers))
@@ -101,7 +101,7 @@ class AddAnApiCheckYourAnswersControllerSpec extends SpecBase with SummaryListFl
           Seq(
             AddAnApiSelectApplicationSummary.row(Some(FakeApplication))(messages(fixture.application)).value,
             AddAnApiApiIdSummary.row(Some(apiDetail))(messages(fixture.application)).value,
-            AddAnApiSelectEndpointsSummary.row(userAnswers, apiDetail, AddAnApi)(messages(fixture.application)).value
+            AddAnApiSelectEndpointsSummary.row(userAnswers, apiDetail, FakeApplication, AddAnApi)(messages(fixture.application)).value
           )
         )
 

--- a/test/controllers/AddAnApiSelectApplicationControllerSpec.scala
+++ b/test/controllers/AddAnApiSelectApplicationControllerSpec.scala
@@ -30,7 +30,7 @@ import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{verify, when}
 import org.scalatestplus.mockito.MockitoSugar
-import pages.{AddAnApiApiIdPage, AddAnApiContextPage, AddAnApiSelectApplicationPage}
+import pages.{AddAnApiApiPage, AddAnApiContextPage, AddAnApiSelectApplicationPage}
 import play.api.data.Form
 import play.api.{Application => PlayApplication}
 import play.api.inject.bind
@@ -143,7 +143,7 @@ class AddAnApiSelectApplicationControllerSpec extends SpecBase with MockitoSugar
     "must populate the view correctly on a GET when the question has previously been answered" in {
       val apiDetail = sampleApiDetail()
       val application = buildApplicationWithoutAccess()
-      val userAnswers = buildUserAnswers(apiDetail).set(AddAnApiSelectApplicationPage, application.id).toOption.value
+      val userAnswers = buildUserAnswers(apiDetail).set(AddAnApiSelectApplicationPage, application).toOption.value
       val fixture = buildFixture(Some(userAnswers))
       val filledForm = form.fill(application.id)
 
@@ -169,7 +169,10 @@ class AddAnApiSelectApplicationControllerSpec extends SpecBase with MockitoSugar
       val application = buildApplicationWithoutAccess()
       val fixture = buildFixture(Some(buildUserAnswers(apiDetail)))
 
-      when(fixture.addAnApiSessionRepository.set(any())).thenReturn(Future.successful(true))
+      when(fixture.apiHubService.getApplication(ArgumentMatchers.eq(application.id), any())(any()))
+        .thenReturn(Future.successful(Some(application)))
+      when(fixture.addAnApiSessionRepository.set(any()))
+        .thenReturn(Future.successful(true))
 
       running(fixture.application) {
         val request = FakeRequest(POST, routes.AddAnApiSelectApplicationController.onSubmit(NormalMode).url)
@@ -186,7 +189,10 @@ class AddAnApiSelectApplicationControllerSpec extends SpecBase with MockitoSugar
       val application = buildApplicationWithoutAccess()
       val fixture = buildFixture(Some(buildUserAnswers(apiDetail)))
 
-      when(fixture.addAnApiSessionRepository.set(any())).thenReturn(Future.successful(true))
+      when(fixture.apiHubService.getApplication(ArgumentMatchers.eq(application.id), any())(any()))
+        .thenReturn(Future.successful(Some(application)))
+      when(fixture.addAnApiSessionRepository.set(any()))
+        .thenReturn(Future.successful(true))
 
       running(fixture.application) {
         val request = FakeRequest(POST, routes.AddAnApiSelectApplicationController.onSubmit(NormalMode).url)
@@ -197,8 +203,8 @@ class AddAnApiSelectApplicationControllerSpec extends SpecBase with MockitoSugar
 
         val expected = UserAnswers(id = FakeUser.userId, lastUpdated = clock.instant())
           .set(AddAnApiContextPage, AddAnApi).toOption.value
-          .set(AddAnApiApiIdPage, apiDetail.id).toOption.value
-          .set(AddAnApiSelectApplicationPage, application.id).toOption.value
+          .set(AddAnApiApiPage, apiDetail).toOption.value
+          .set(AddAnApiSelectApplicationPage, application).toOption.value
 
         verify(fixture.addAnApiSessionRepository).set(ArgumentMatchers.eq(expected))
       }
@@ -318,7 +324,7 @@ class AddAnApiSelectApplicationControllerSpec extends SpecBase with MockitoSugar
   private def buildUserAnswers(apiDetail: ApiDetail): UserAnswers = {
     UserAnswers(id = FakeUser.userId, lastUpdated = clock.instant())
       .set(AddAnApiContextPage, AddAnApi).toOption.value
-      .set(AddAnApiApiIdPage, apiDetail.id).toOption.value
+      .set(AddAnApiApiPage, apiDetail).toOption.value
   }
 
 }

--- a/test/controllers/AddAnApiSelectEndpointsControllerSpec.scala
+++ b/test/controllers/AddAnApiSelectEndpointsControllerSpec.scala
@@ -20,17 +20,20 @@ import base.SpecBase
 import controllers.actions.{FakeApplication, FakeUser}
 import forms.AddAnApiSelectEndpointsFormProvider
 import generators.ApiDetailGenerators
-import models.api.ApiDetail
+import models.api.{ApiDetail, Endpoint, EndpointMethod}
+import models.application.{Api, Application, SelectedEndpoint}
 import models.{AddAnApi, AvailableEndpoints, NormalMode, UserAnswers}
+import models.application.ApplicationLenses._
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{verify, when}
 import org.scalatestplus.mockito.MockitoSugar
 import pages.{AddAnApiApiPage, AddAnApiContextPage, AddAnApiSelectApplicationPage, AddAnApiSelectEndpointsPage}
-import play.api.Application
+import play.api.{Application => PlayApplication}
+import play.api.i18n.Messages
 import play.api.inject.bind
-import play.api.mvc.Call
+import play.api.mvc.{AnyContentAsEmpty, AnyContentAsFormUrlEncoded, Call}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import repositories.AddAnApiSessionRepository
@@ -60,13 +63,14 @@ class AddAnApiSelectEndpointsControllerSpec extends SpecBase with MockitoSugar w
         .thenReturn(Future.successful(Some(apiDetail)))
 
       running(fixture.application) {
-        val request = FakeRequest(GET, addAnApiSelectEndpointsRoute)
+        implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(GET, addAnApiSelectEndpointsRoute)
+        implicit val msgs: Messages = messages(fixture.application)
         val result = route(fixture.application, request).value
         val view = fixture.application.injector.instanceOf[AddAnApiSelectEndpointsView]
 
         status(result) mustEqual OK
 
-        contentAsString(result) mustEqual view(form, NormalMode, AddAnApi, Some(FakeUser), apiDetail, FakeApplication)(request, messages(fixture.application)).toString
+        contentAsString(result) mustEqual view(form, NormalMode, AddAnApi, Some(FakeUser), apiDetail, FakeApplication).toString
         contentAsString(result) must validateAsHtml
       }
     }
@@ -81,13 +85,14 @@ class AddAnApiSelectEndpointsControllerSpec extends SpecBase with MockitoSugar w
         .thenReturn(Future.successful(Some(apiDetail)))
 
       running(fixture.application) {
-        val request = FakeRequest(GET, addAnApiSelectEndpointsRoute)
+        implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(GET, addAnApiSelectEndpointsRoute)
+        implicit val msgs: Messages = messages(fixture.application)
         val view = fixture.application.injector.instanceOf[AddAnApiSelectEndpointsView]
         val result = route(fixture.application, request).value
 
         status(result) mustEqual OK
         contentAsString(result) mustEqual
-          view(form.fill(AvailableEndpoints(apiDetail, FakeApplication).keySet), NormalMode, AddAnApi, Some(FakeUser), apiDetail, FakeApplication)(request, messages(fixture.application)).toString
+          view(form.fill(AvailableEndpoints(apiDetail, FakeApplication).keySet), NormalMode, AddAnApi, Some(FakeUser), apiDetail, FakeApplication).toString
         contentAsString(result) must validateAsHtml
       }
     }
@@ -136,6 +141,44 @@ class AddAnApiSelectEndpointsControllerSpec extends SpecBase with MockitoSugar w
       }
     }
 
+    "must add further endpoints to an existing answer (add endpoints journey)" in {
+      val apiDetail = sampleApiDetail()
+        .copy(
+          endpoints = Seq(
+            Endpoint("/test-path-1", Seq(EndpointMethod("GET", None, None, Seq("test-scope-1")))),
+            Endpoint("/test-path-2", Seq(EndpointMethod("GET", None, None, Seq("test-scope-2")))),
+            Endpoint("/test-path-3", Seq(EndpointMethod("GET", None, None, Seq("test-scope-3"))))
+          )
+        )
+
+      val application = FakeApplication
+        .addApi(
+          Api(apiDetail.id, Seq(SelectedEndpoint("GET", "/test-path-2")))
+        )
+
+      val fixture = buildFixture(Some(buildUserAnswers(apiDetail, application)))
+
+      when(fixture.apiHubService.getApiDetail(ArgumentMatchers.eq(apiDetail.id))(any()))
+        .thenReturn(Future.successful(Some(apiDetail)))
+
+      when(fixture.addAnApiSessionRepository.set(any())) thenReturn Future.successful(true)
+
+      running(fixture.application) {
+        val request =
+          FakeRequest(POST, addAnApiSelectEndpointsRoute)
+            .withFormUrlEncodedBody(("value[0]", Set("test-scope-1").toString()))
+
+        val result = route(fixture.application, request).value
+
+        status(result) mustEqual SEE_OTHER
+
+        val expected = buildUserAnswers(apiDetail, application)
+          .set(AddAnApiSelectEndpointsPage, Set(Set("test-scope-1"), Set("test-scope-2"))).toOption.value
+
+        verify(fixture.addAnApiSessionRepository).set(ArgumentMatchers.eq(expected))
+      }
+    }
+
     "must return a Bad Request and errors when invalid data is submitted" in {
       val fixture = buildFixture(Some(buildUserAnswers(apiDetail)))
 
@@ -143,9 +186,10 @@ class AddAnApiSelectEndpointsControllerSpec extends SpecBase with MockitoSugar w
         .thenReturn(Future.successful(Some(apiDetail)))
 
       running(fixture.application) {
-        val request =
+        implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] =
           FakeRequest(POST, addAnApiSelectEndpointsRoute)
             .withFormUrlEncodedBody(("value", "invalid value"))
+        implicit val msgs: Messages = messages(fixture.application)
 
         val boundForm = form.bind(Map("value" -> "invalid value"))
 
@@ -154,7 +198,7 @@ class AddAnApiSelectEndpointsControllerSpec extends SpecBase with MockitoSugar w
         val result = route(fixture.application, request).value
 
         status(result) mustEqual BAD_REQUEST
-        contentAsString(result) mustEqual view(boundForm, NormalMode, AddAnApi, Some(FakeUser), apiDetail, FakeApplication)(request, messages(fixture.application)).toString
+        contentAsString(result) mustEqual view(boundForm, NormalMode, AddAnApi, Some(FakeUser), apiDetail, FakeApplication).toString
         contentAsString(result) must validateAsHtml
       }
     }
@@ -189,7 +233,7 @@ class AddAnApiSelectEndpointsControllerSpec extends SpecBase with MockitoSugar w
   }
 
   private case class Fixture(
-    application: Application,
+    application: PlayApplication,
     apiHubService: ApiHubService,
     addAnApiSessionRepository: AddAnApiSessionRepository
   )
@@ -210,11 +254,11 @@ class AddAnApiSelectEndpointsControllerSpec extends SpecBase with MockitoSugar w
     Fixture(application, apiHubService, addAnApiSessionRepository)
   }
 
-  private def buildUserAnswers(apiDetail: ApiDetail): UserAnswers = {
+  private def buildUserAnswers(apiDetail: ApiDetail, application: Application = FakeApplication): UserAnswers = {
     UserAnswers(id = FakeUser.userId, lastUpdated = clock.instant())
       .set(AddAnApiApiPage, apiDetail).toOption.value
       .set(AddAnApiContextPage, AddAnApi).toOption.value
-      .set(AddAnApiSelectApplicationPage, FakeApplication).toOption.value
+      .set(AddAnApiSelectApplicationPage, application).toOption.value
   }
 
 }

--- a/test/controllers/AddAnApiStartControllerSpec.scala
+++ b/test/controllers/AddAnApiStartControllerSpec.scala
@@ -17,15 +17,18 @@
 package controllers
 
 import base.SpecBase
-import controllers.actions.FakeUser
+import controllers.actions.{FakeApplication, FakeUser}
 import generators.ApiDetailGenerators
-import models.{AddAnApi, UserAnswers}
+import models.api.{Endpoint, EndpointMethod}
+import models.application.{Api, SelectedEndpoint}
+import models.{AddAnApi, AddEndpoints, UserAnswers}
+import models.application.ApplicationLenses._
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{verify, when}
 import org.scalatestplus.mockito.MockitoSugar
-import pages.{AddAnApiApiPage, AddAnApiContextPage}
+import pages.{AddAnApiApiPage, AddAnApiContextPage, AddAnApiSelectApplicationPage, AddAnApiSelectEndpointsPage}
 import play.api.Application
 import play.api.inject.bind
 import play.api.test.FakeRequest
@@ -44,7 +47,7 @@ class AddAnApiStartControllerSpec extends SpecBase with MockitoSugar with HtmlVa
   private val clock = Clock.fixed(Instant.now(), ZoneId.systemDefault())
 
   "AddAnApiStartController" - {
-    "must initiate user answers with the Api Id and persist this in the session repository" in {
+    "must initiate user answers with the context and Api Id and persist this in the session repository (add an API journey)" in {
       val fixture = buildFixture()
       val apiDetail = sampleApiDetail()
 
@@ -62,6 +65,43 @@ class AddAnApiStartControllerSpec extends SpecBase with MockitoSugar with HtmlVa
         val expected = UserAnswers(id = FakeUser.userId, lastUpdated = clock.instant())
           .set(AddAnApiApiPage, apiDetail)
           .flatMap(_.set(AddAnApiContextPage, AddAnApi))
+          .toOption.value
+
+        verify(fixture.addAnApiSessionRepository).set(ArgumentMatchers.eq(expected))
+      }
+    }
+
+    "must initiate user answers with the context and Api Id and persist this in the session repository (add endpoints journey)" in {
+      val fixture = buildFixture()
+      val apiDetail = sampleApiDetail()
+        .copy(
+          endpoints = Seq(
+            Endpoint("/test-path-1", Seq(EndpointMethod("GET", None, None, Seq("test-scope-1"))))
+          )
+        )
+      val application = FakeApplication
+        .addApi(
+          Api(apiDetail.id, Seq(SelectedEndpoint("GET", "/test-path-1")))
+        )
+
+      when(fixture.apiHubService.getApplication(ArgumentMatchers.eq(application.id), any())(any()))
+        .thenReturn(Future.successful(Some(application)))
+      when(fixture.apiHubService.getApiDetail(ArgumentMatchers.eq(apiDetail.id))(any()))
+        .thenReturn(Future.successful(Some(apiDetail)))
+
+      when(fixture.addAnApiSessionRepository.set(any())).thenReturn(Future.successful(true))
+
+      running(fixture.application) {
+        val request = FakeRequest(GET, routes.AddAnApiStartController.addEndpoints(application.id, apiDetail.id).url)
+        val result = route(fixture.application, request).value
+
+        status(result) mustBe SEE_OTHER
+
+        val expected = UserAnswers(id = FakeUser.userId, lastUpdated = clock.instant())
+          .set(AddAnApiApiPage, apiDetail)
+          .flatMap(_.set(AddAnApiContextPage, AddEndpoints))
+          .flatMap(_.set(AddAnApiSelectApplicationPage, application))
+          .flatMap(_.set(AddAnApiSelectEndpointsPage, Set(Set("test-scope-1"))))
           .toOption.value
 
         verify(fixture.addAnApiSessionRepository).set(ArgumentMatchers.eq(expected))

--- a/test/controllers/AddAnApiStartControllerSpec.scala
+++ b/test/controllers/AddAnApiStartControllerSpec.scala
@@ -25,7 +25,7 @@ import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{verify, when}
 import org.scalatestplus.mockito.MockitoSugar
-import pages.{AddAnApiApiIdPage, AddAnApiContextPage}
+import pages.{AddAnApiApiPage, AddAnApiContextPage}
 import play.api.Application
 import play.api.inject.bind
 import play.api.test.FakeRequest
@@ -60,7 +60,7 @@ class AddAnApiStartControllerSpec extends SpecBase with MockitoSugar with HtmlVa
         status(result) mustBe SEE_OTHER
 
         val expected = UserAnswers(id = FakeUser.userId, lastUpdated = clock.instant())
-          .set(AddAnApiApiIdPage, apiDetail.id)
+          .set(AddAnApiApiPage, apiDetail)
           .flatMap(_.set(AddAnApiContextPage, AddAnApi))
           .toOption.value
 

--- a/test/controllers/ApiPolicyConditionsDeclarationPageControllerSpec.scala
+++ b/test/controllers/ApiPolicyConditionsDeclarationPageControllerSpec.scala
@@ -27,7 +27,7 @@ import org.mockito.{ArgumentCaptor, ArgumentMatchers}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{verify, when}
 import org.scalatestplus.mockito.MockitoSugar
-import pages.{AddAnApiApiIdPage, AddAnApiContextPage, AddAnApiSelectApplicationPage, ApiPolicyConditionsDeclarationPage}
+import pages.{AddAnApiApiPage, AddAnApiContextPage, AddAnApiSelectApplicationPage, ApiPolicyConditionsDeclarationPage}
 import play.api.data.Form
 import play.api.inject.bind
 import play.api.mvc.Request
@@ -71,7 +71,7 @@ class ApiPolicyConditionsDeclarationPageControllerSpec extends SpecBase with Moc
     "must populate the view correctly on a GET" in {
       val apiDetail = sampleApiDetail()
       val application = FakeApplication
-      val userAnswers = buildUserAnswers(apiDetail).set(AddAnApiSelectApplicationPage, application.id).toOption.value
+      val userAnswers = buildUserAnswers(apiDetail).set(AddAnApiSelectApplicationPage, application).toOption.value
       val fixture = buildFixture(Some(userAnswers))
 
       when(fixture.apiHubService.getApiDetail(ArgumentMatchers.eq(apiDetail.id))(any()))
@@ -203,7 +203,7 @@ class ApiPolicyConditionsDeclarationPageControllerSpec extends SpecBase with Moc
   private def buildUserAnswers(apiDetail: ApiDetail): UserAnswers = {
     UserAnswers(id = FakeUser.userId, lastUpdated = clock.instant())
       .set(AddAnApiContextPage, AddAnApi).toOption.value
-      .set(AddAnApiApiIdPage, apiDetail.id).toOption.value
+      .set(AddAnApiApiPage, apiDetail).toOption.value
   }
 
 }

--- a/test/forms/AddAnApiSelectEndpointsFormProviderSpec.scala
+++ b/test/forms/AddAnApiSelectEndpointsFormProviderSpec.scala
@@ -16,6 +16,7 @@
 
 package forms
 
+import controllers.actions.FakeApplication
 import forms.behaviours.CheckboxFieldBehaviours
 import generators.ApiDetailGenerators
 import models.AvailableEndpoints
@@ -24,7 +25,7 @@ import play.api.data.FormError
 class AddAnApiSelectEndpointsFormProviderSpec extends CheckboxFieldBehaviours with ApiDetailGenerators {
 
   private val apiDetail = sampleApiDetail()
-  private val form = new AddAnApiSelectEndpointsFormProvider()(apiDetail)
+  private val form = new AddAnApiSelectEndpointsFormProvider()(apiDetail, FakeApplication)
 
   ".value" - {
 
@@ -34,7 +35,7 @@ class AddAnApiSelectEndpointsFormProviderSpec extends CheckboxFieldBehaviours wi
     behave like checkboxField[Set[String]](
       form,
       fieldName,
-      validValues  = AvailableEndpoints(apiDetail).keySet.toSeq,
+      validValues  = AvailableEndpoints(apiDetail, FakeApplication).keySet.toSeq,
       invalidError = FormError(s"$fieldName[0]", "error.invalid")
     )
 

--- a/test/models/AvailableEndpointsSpec.scala
+++ b/test/models/AvailableEndpointsSpec.scala
@@ -16,6 +16,7 @@
 
 package models
 
+import controllers.actions.FakeApplication
 import models.api.ApiDetailLensesSpec.sampleOas
 import models.api.{ApiDetail, Endpoint, EndpointMethod}
 import org.scalatest.freespec.AnyFreeSpec
@@ -84,13 +85,13 @@ class AvailableEndpointsSpec extends AnyFreeSpec with Matchers with TableDrivenP
 
         val expected = Map(
           scopes.toSet -> Seq(
-            AvailableEndpoint(path1, endpoint1method1),
-            AvailableEndpoint(path1, endpoint1method2),
-            AvailableEndpoint(path2, endpoint2method1)
+            AvailableEndpoint(path1, endpoint1method1, false),
+            AvailableEndpoint(path1, endpoint1method2, false),
+            AvailableEndpoint(path2, endpoint2method1, false)
           )
         )
 
-        val actual = AvailableEndpoints(apiDetail)
+        val actual = AvailableEndpoints(apiDetail, FakeApplication)
 
         actual mustBe expected
       }
@@ -157,16 +158,16 @@ class AvailableEndpointsSpec extends AnyFreeSpec with Matchers with TableDrivenP
 
         val expected = Map(
           scopes1.toSet -> Seq(
-            AvailableEndpoint(path1, endpoint1method1),
-            AvailableEndpoint(path2, endpoint2method1)
+            AvailableEndpoint(path1, endpoint1method1, false),
+            AvailableEndpoint(path2, endpoint2method1, false)
           ),
           scopes2.toSet -> Seq(
-            AvailableEndpoint(path1, endpoint1method2),
-            AvailableEndpoint(path3, endpoint3method1)
+            AvailableEndpoint(path1, endpoint1method2, false),
+            AvailableEndpoint(path3, endpoint3method1, false)
           )
         )
 
-        val actual = AvailableEndpoints(apiDetail)
+        val actual = AvailableEndpoints(apiDetail, FakeApplication)
 
         actual mustBe expected
       }
@@ -246,11 +247,11 @@ class AvailableEndpointsSpec extends AnyFreeSpec with Matchers with TableDrivenP
         )
       )
 
-      val actual = AvailableEndpoints.selectedEndpoints(apiDetail, Set(scopes1.toSet, scopes2.toSet))
+      val actual = AvailableEndpoints.selectedEndpoints(apiDetail, FakeApplication, Set(scopes1.toSet, scopes2.toSet))
 
       val expected = Map(
-        scopes1.toSet -> Seq(AvailableEndpoint(path1, endpoint1method1), AvailableEndpoint(path2, endpoint2method1)),
-        scopes2.toSet -> Seq(AvailableEndpoint(path1, endpoint1method2), AvailableEndpoint(path3, endpoint3method1))
+        scopes1.toSet -> Seq(AvailableEndpoint(path1, endpoint1method1, false), AvailableEndpoint(path2, endpoint2method1, false)),
+        scopes2.toSet -> Seq(AvailableEndpoint(path1, endpoint1method2, false), AvailableEndpoint(path3, endpoint3method1, false))
       )
 
       actual mustBe expected
@@ -277,7 +278,7 @@ class AvailableEndpointsSpec extends AnyFreeSpec with Matchers with TableDrivenP
         )
       )
 
-      val actual = AvailableEndpoints.selectedEndpoints(apiDetail, Set(Set("no-match")))
+      val actual = AvailableEndpoints.selectedEndpoints(apiDetail, FakeApplication, Set(Set("no-match")))
 
       actual mustBe empty
     }
@@ -303,7 +304,7 @@ class AvailableEndpointsSpec extends AnyFreeSpec with Matchers with TableDrivenP
         )
       )
 
-      val actual = AvailableEndpoints.selectedEndpoints(apiDetail, Set.empty[Set[String]])
+      val actual = AvailableEndpoints.selectedEndpoints(apiDetail, FakeApplication, Set.empty[Set[String]])
 
       actual mustBe empty
     }

--- a/test/models/AvailableEndpointsSpec.scala
+++ b/test/models/AvailableEndpointsSpec.scala
@@ -19,6 +19,8 @@ package models
 import controllers.actions.FakeApplication
 import models.api.ApiDetailLensesSpec.sampleOas
 import models.api.{ApiDetail, Endpoint, EndpointMethod}
+import models.application.{Api, SelectedEndpoint}
+import models.application.ApplicationLenses._
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
@@ -35,7 +37,7 @@ class AvailableEndpointsSpec extends AnyFreeSpec with Matchers with TableDrivenP
     openApiSpecification = sampleOas
   )
 
-  "apply" - {
+  "AvailableEndpoints.apply" - {
     "must group endpoint methods by the same set of scopes" in {
       val scopeSets = Table(
         "Scopes",
@@ -307,6 +309,37 @@ class AvailableEndpointsSpec extends AnyFreeSpec with Matchers with TableDrivenP
       val actual = AvailableEndpoints.selectedEndpoints(apiDetail, FakeApplication, Set.empty[Set[String]])
 
       actual mustBe empty
+    }
+  }
+
+  "AvailableEndpoint.apply" - {
+    val endpointMethod1 = EndpointMethod("GET", None, None, Seq("test-scope-1"))
+    val endpointMethod2 = EndpointMethod("GET", None, None, Seq("test-scope-2"))
+
+    val endpoint1 = Endpoint("/test-path-1", Seq(endpointMethod1))
+    val endpoint2 = Endpoint("/test-path-2", Seq(endpointMethod2))
+
+    val apiDetail = testApiDetail.copy(
+      endpoints = Seq(
+        endpoint1,
+        endpoint2
+      )
+    )
+
+    val application = FakeApplication.addApi(
+      Api(apiDetail.id, Seq(SelectedEndpoint("GET", "/test-path-1")))
+    )
+
+    "must set the added attribute correctly when the endpoint has been added to the application" in {
+      val actual = AvailableEndpoint.apply("/test-path-1", endpointMethod1, apiDetail, application)
+
+      actual mustBe AvailableEndpoint("/test-path-1", endpointMethod1, true)
+    }
+
+    "must set the added attribute correctly when the endpoint has not been added to the application" in {
+      val actual = AvailableEndpoint.apply("/test-path-2", endpointMethod2, apiDetail, application)
+
+      actual mustBe AvailableEndpoint("/test-path-2", endpointMethod2, false)
     }
   }
 

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -72,7 +72,7 @@ class NavigatorSpec extends SpecBase with TryValues {
 
       "during the Add an API journey" - {
         "must go from the Add An API API Id (start) page to the Select Application page" in {
-          navigator.nextPage(AddAnApiApiIdPage, NormalMode, buildUserAnswers(AddAnApi)) mustBe routes.AddAnApiSelectApplicationController.onPageLoad(NormalMode)
+          navigator.nextPage(AddAnApiApiPage, NormalMode, buildUserAnswers(AddAnApi)) mustBe routes.AddAnApiSelectApplicationController.onPageLoad(NormalMode)
         }
 
         "must go from the Add An API Select Application page to the Select Endpoints page" in {
@@ -90,7 +90,7 @@ class NavigatorSpec extends SpecBase with TryValues {
 
       "during the Add Endpoints journey" - {
         "must go from the Add An API API Id (start) page to the Select Endpoints page" in {
-          navigator.nextPage(AddAnApiApiIdPage, NormalMode, buildUserAnswers(AddEndpoints)) mustBe routes.AddAnApiSelectEndpointsController.onPageLoad(NormalMode, AddEndpoints)
+          navigator.nextPage(AddAnApiApiPage, NormalMode, buildUserAnswers(AddEndpoints)) mustBe routes.AddAnApiSelectEndpointsController.onPageLoad(NormalMode, AddEndpoints)
         }
 
         "must go from the Add An API Select Endpoints page to the Accept Policy Conditions page" in {

--- a/test/pages/AddAnApiApiPageSpec.scala
+++ b/test/pages/AddAnApiApiPageSpec.scala
@@ -16,12 +16,19 @@
 
 package pages
 
-import play.api.libs.json.JsPath
+import generators.ApiDetailGenerators
+import models.api.ApiDetail
+import pages.behaviours.PageBehaviours
 
-case object AddAnApiApiIdPage extends QuestionPage[String] {
+class AddAnApiApiPageSpec extends PageBehaviours with ApiDetailGenerators {
 
-  override def path: JsPath = JsPath \ toString
+  "AddAnApiApiIdPage" - {
 
-  override def toString: String = "apiId"
+    beRetrievable[ApiDetail](AddAnApiApiPage)
+
+    beSettable[ApiDetail](AddAnApiApiPage)
+
+    beRemovable[ApiDetail](AddAnApiApiPage)
+  }
 
 }

--- a/test/pages/AddAnApiSelectApplicationPageSpec.scala
+++ b/test/pages/AddAnApiSelectApplicationPageSpec.scala
@@ -16,17 +16,19 @@
 
 package pages
 
+import generators.ApplicationGenerator
+import models.application.Application
 import pages.behaviours.PageBehaviours
 
-class AddAnApiSelectApplicationPageSpec extends PageBehaviours {
+class AddAnApiSelectApplicationPageSpec extends PageBehaviours with ApplicationGenerator {
 
   "AddAnApiSelectApplicationPage" - {
 
-    beRetrievable[String](AddAnApiSelectApplicationPage)
+    beRetrievable[Application](AddAnApiSelectApplicationPage)
 
-    beSettable[String](AddAnApiSelectApplicationPage)
+    beSettable[Application](AddAnApiSelectApplicationPage)
 
-    beRemovable[String](AddAnApiSelectApplicationPage)
+    beRemovable[Application](AddAnApiSelectApplicationPage)
   }
 
 }

--- a/test/services/ApiHubServiceSpec.scala
+++ b/test/services/ApiHubServiceSpec.scala
@@ -306,7 +306,7 @@ class ApiHubServiceSpec
       val verb = "GET"
       val path = "/foo/bar"
       val scopes = Seq("test-scope-1", "test-scope-2")
-      val availableEndpoints = Seq(AvailableEndpoint(path, EndpointMethod(verb, None, None, scopes)))
+      val availableEndpoints = Seq(AvailableEndpoint(path, EndpointMethod(verb, None, None, scopes), false))
 
       val apiRequest = AddApiRequest(apiId, Seq(AddApiRequestEndpoint(verb, path)), scopes)
 

--- a/test/viewmodels/checkAnswers/AddAnApiSelectEndpointsSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/AddAnApiSelectEndpointsSummarySpec.scala
@@ -16,7 +16,7 @@
 
 package viewmodels.checkAnswers
 
-import controllers.actions.FakeUser
+import controllers.actions.{FakeApplication, FakeUser}
 import controllers.routes
 import models.api.ApiDetailLensesSpec.sampleOas
 import models.api.{ApiDetail, Endpoint, EndpointMethod}
@@ -70,6 +70,7 @@ class AddAnApiSelectEndpointsSummarySpec extends AnyFreeSpec with Matchers with 
       val actual = AddAnApiSelectEndpointsSummary.row(
         userAnswers,
         apiDetail,
+        FakeApplication,
         AddAnApi
       )
 
@@ -98,6 +99,7 @@ class AddAnApiSelectEndpointsSummarySpec extends AnyFreeSpec with Matchers with 
       val actual = AddAnApiSelectEndpointsSummary.row(
         UserAnswers(FakeUser.userId, Json.obj(), Instant.now()),
         apiDetail,
+        FakeApplication,
         AddAnApi
       )
 


### PR DESCRIPTION
https://jira.tools.tax.service.gov.uk/browse/HIPP-917

There's some refactoring in this PR. Both the API Id and Application Id in user answers have been replaced with the objects rather than identifiers. This is because we need access to them much more often to identify which endpoints have been added previously, ie in a prior add an API or add endpoints journey.