### PR TITLE
Shuttering the service

### DIFF
--- a/app/controllers/ShutterController.scala
+++ b/app/controllers/ShutterController.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import com.google.inject.Inject
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import play.api.routing.Router.Routes
+import play.api.routing.SimpleRouter
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+
+class ShutterController @Inject()(
+  val controllerComponents: MessagesControllerComponents
+) extends FrontendBaseController with SimpleRouter with I18nSupport {
+
+  override def routes: Routes =  {
+    case _ => this.shuttered()
+  }
+
+  def shuttered(): Action[AnyContent] = Action {
+    Ok("The API Hub is down for maintenance. Please come back shortly.")
+  }
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ lazy val root = (project in file("."))
     ),
     PlayKeys.playDefaultPort := 9000,
     PlayKeys.devSettings ++= Seq(
-      "play.http.router" -> "testOnlyDoNotUseInAppConf.Routes",
+      "play.http.router" -> "shutter.Routes",
       "microservice.services.internal-auth.url" -> "http://localhost:9000/api-hub/test-only",
       "urls.loginWithLdap" -> "http://localhost:9000/api-hub/test-only/sign-in"
     ),

--- a/conf/shutter.routes
+++ b/conf/shutter.routes
@@ -1,0 +1,4 @@
+->         /api-hub                   controllers.ShutterController
+->         /                          health.Routes
+
+GET        /admin/metrics             @com.kenshoo.play.metrics.MetricsController.metrics


### PR DESCRIPTION
A simple shuttering of the service by adding a router we can configure in place of the prod router.

We configure the router with the configuration item `play.http.router`. In production this is `prod.Routes` and in other environments it is `testOnlyDoNotUseInAppConf.Routes`. In this branch it has been changed in `build.sbt` to `shutter.Routes`. See line 37. You can change it back to testOnlyDoNotUseInAppConf.Routes and the service will work as normal.

You can test this using `sbt run` and visiting the service locally on port 9000.

The shutter router basically routes every request on `/api-hub` to some static content that states the service is down for maintenance. It is actually both a router and a controller.

We still want to serve up health and metrics endpoints while shuttered.
