### PR TITLE
Add support view of APIs

### DIFF
--- a/app/controllers/ApiSupportController.scala
+++ b/app/controllers/ApiSupportController.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import com.google.inject.{Inject, Singleton}
+import controllers.actions.{AuthorisedSupportAction, IdentifierAction}
+import models.api.ApiDetail
+import play.api.i18n.I18nSupport
+import play.api.libs.json.Json
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Request}
+import services.ApiHubService
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class ApiSupportController @Inject()(
+  override val controllerComponents: MessagesControllerComponents,
+  identify: IdentifierAction,
+  isSupport: AuthorisedSupportAction,
+  apiHubService: ApiHubService
+)(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  def onPageLoad(id: String): Action[AnyContent] = (identify andThen isSupport).async {
+    implicit request =>
+      apiHubService
+        .getApiDetail(id)
+        .map {
+          case Some(apiDetail) => Ok(Json.toJson(buildApiDetail(apiDetail)))
+          case _ => NotFound
+        }
+  }
+
+  private def buildApiDetail(apiDetail: ApiDetail)(implicit request: Request[_]): ApiDetail = {
+    apiDetail.copy(
+      openApiSpecification = controllers.routes.OasRedocController.getOas(apiDetail.id).absoluteURL()
+    )
+  }
+
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -60,6 +60,7 @@ GET         /sign-in                                                           c
 GET         /test-connectivity                                                 controllers.TestConnectivityController.onPageLoad()
 
 GET         /apis/details/:id                                                  controllers.ApiDetailsController.onPageLoad(id: String)
+GET         /apis/support/:id                                                  controllers.ApiSupportController.onPageLoad(id: String)
 
 GET         /apis/add-an-api/start/:id                                         controllers.AddAnApiStartController.addAnApi(id: String)
 GET         /apis/add-endpoints/start/:applicationId/:apiId                    controllers.AddAnApiStartController.addEndpoints(applicationId: String, apiId: String)

--- a/test/controllers/ApiSupportControllerSpec.scala
+++ b/test/controllers/ApiSupportControllerSpec.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import base.SpecBase
+import generators.ApiDetailGenerators
+import models.user.UserModel
+import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
+import play.api.inject.bind
+import play.api.libs.json.Json
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import play.api.{Application => PlayApplication}
+import services.ApiHubService
+import utils.TestHelpers
+
+import scala.concurrent.Future
+
+class ApiSupportControllerSpec
+  extends SpecBase
+    with MockitoSugar
+    with ArgumentMatchersSugar
+    with TestHelpers
+    with ApiDetailGenerators {
+
+  "onPageLoad" - {
+    "must return the correct ApiDetail as JSON to a user with the support role" in {
+      val apiDetail = sampleApiDetail()
+
+      forAll(usersWhoCanSupport) { (user: UserModel) =>
+        val fixture = buildFixture(user)
+
+        when(fixture.apiHubService.getApiDetail(eqTo(apiDetail.id))(any)).thenReturn(Future.successful(Some(apiDetail)))
+
+        running(fixture.playApplication) {
+          val request = FakeRequest(controllers.routes.ApiSupportController.onPageLoad(apiDetail.id))
+          val result = route(fixture.playApplication, request).value
+
+          val expected = apiDetail.copy(
+            openApiSpecification = controllers.routes.OasRedocController.getOas(apiDetail.id).absoluteURL()(request)
+          )
+
+          status(result) mustBe OK
+          contentAsJson(result) mustBe Json.toJson(expected)
+        }
+      }
+    }
+
+    "must redirect to the unauthorised page for a user who is not support" in {
+      forAll(usersWhoCannotSupport) {(user: UserModel) =>
+        val fixture = buildFixture(user)
+
+        running(fixture.playApplication) {
+          val request = FakeRequest(controllers.routes.ApiSupportController.onPageLoad("test-id"))
+          val result = route(fixture.playApplication, request).value
+
+          status(result) mustBe SEE_OTHER
+          redirectLocation(result) mustBe Some(routes.UnauthorisedController.onPageLoad.url)
+        }
+      }
+    }
+  }
+
+  private case class Fixture(playApplication: PlayApplication, apiHubService: ApiHubService)
+
+  private def buildFixture(userModel: UserModel): Fixture = {
+    val apiHubService = mock[ApiHubService]
+
+    val playApplication = applicationBuilder(userAnswers = Some(emptyUserAnswers), user = userModel)
+      .overrides(
+        bind[ApiHubService].toInstance(apiHubService)
+      ).build()
+
+    Fixture(playApplication, apiHubService)
+  }
+
+}


### PR DESCRIPTION
To see the support view go to /api-hub/apis/support/<API Id>
This returns a JSON representation of the ApiDetail object
The OAS spec is replaced with a URL to view it so as to not make the JSON view difficult to read
