### PR TITLE
HIPP-1449: Fix broken links to the guide

### DIFF
--- a/app/views/application/EnvironmentAndCredentialsView.scala.html
+++ b/app/views/application/EnvironmentAndCredentialsView.scala.html
@@ -42,7 +42,7 @@
 }
 
 @rolesGuidanceLink() = {
-    <a class="govuk-link" href="@apiHubGuideUrl/documentation/api-hub-guide.html#api-hub-roles">@messages("environmentAndCredentials.notPrivileged.additional3")</a>
+    <a class="govuk-link" href="@apiHubGuideUrl/documentation/what-access-do-i-need.html#what-access-do-i-need">@messages("environmentAndCredentials.notPrivileged.additional3")</a>
 }
 
 @developmentTab() = {

--- a/app/views/auth/SignInView.scala.html
+++ b/app/views/auth/SignInView.scala.html
@@ -64,7 +64,7 @@
 
                 <p class="govuk-body-s">
                     @messages("signIn.stride.help")
-                    @newTabLink(apiHubGuideUrl + "/documentation/api-hub-guide.html#how-do-you-get-access-to-it", messages("signIn.stride.helpLink"))
+                    @newTabLink(apiHubGuideUrl + "/documentation/what-access-do-i-need.html#what-access-do-i-need", messages("signIn.stride.helpLink"))
                 </p>
             </div>
         </div>


### PR DESCRIPTION
[HIPP-1449](https://jira.tools.tax.service.gov.uk/browse/HIPP-1449) mentions only one link, but there's two links pointing to the guide and both were pointing to a non-existent screen.