### PR TITLE
HIPP-1459: Redirect api-hub requests to integration-hub

### DIFF
--- a/app/routes/OldRoutes.scala
+++ b/app/routes/OldRoutes.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package routes
+
+import play.api.mvc._
+import play.api.routing.Router.Routes
+import play.api.routing.SimpleRouter
+import play.api.routing.sird._
+
+import javax.inject.Inject
+
+class OldRoutes @Inject()(
+                           val cc: MessagesControllerComponents
+                         ) extends SimpleRouter {
+  private val oldPath = "/api-hub"
+  private val newPath = "/integration-hub"
+
+  private object RedirectController extends ControllerHelpers {
+    private val Action = new ActionBuilder.IgnoringBody()(controllers.Execution.trampoline)
+
+    def redirect(to: String): Action[AnyContent] = Action {
+      Redirect(s"$newPath$to", statusCode = MOVED_PERMANENTLY)
+    }
+  }
+
+  override def routes: Routes = {
+    case GET(path) =>
+      RedirectController.redirect(path.path.replace(oldPath, ""))
+  }
+}
+

--- a/app/routes/OldRoutes.scala
+++ b/app/routes/OldRoutes.scala
@@ -16,30 +16,17 @@
 
 package routes
 
-import play.api.mvc._
+import controllers.Default
 import play.api.routing.Router.Routes
 import play.api.routing.SimpleRouter
 import play.api.routing.sird._
 
 import javax.inject.Inject
 
-class OldRoutes @Inject()(
-                           val cc: MessagesControllerComponents
-                         ) extends SimpleRouter {
-  private val oldPath = "/api-hub"
-  private val newPath = "/integration-hub"
-
-  private object RedirectController extends ControllerHelpers {
-    private val Action = new ActionBuilder.IgnoringBody()(controllers.Execution.trampoline)
-
-    def redirect(to: String): Action[AnyContent] = Action {
-      Redirect(s"$newPath$to", statusCode = MOVED_PERMANENTLY)
-    }
-  }
-
+class OldRoutes @Inject()(defaultController: Default) extends SimpleRouter {
   override def routes: Routes = {
-    case GET(path) =>
-      RedirectController.redirect(path.path.replace(oldPath, ""))
+    case GET(request) =>
+      defaultController.redirect(s"/integration-hub${request.path}")
   }
 }
 

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -1,4 +1,4 @@
 # Add all the application routes to the app.routes file
-->         /api-hub                   app.Routes
 ->         /integration-hub           app.Routes
 ->         /                          health.Routes
+->         /api-hub                   routes.OldRoutes

--- a/test/routes/OldRoutesSpec.scala
+++ b/test/routes/OldRoutesSpec.scala
@@ -41,14 +41,14 @@ class OldRoutesSpec
 
   implicit override def newAppForTest(testData: TestData): Application =
     new GuiceApplicationBuilder()
-      .configure(testData.configMap ++ Map("play.http.router" -> "routes.OldRoutes"))
+      .configure(testData.configMap ++ Map("play.http.router" -> "prod.Routes"))
       .build()
 
   "OldRoutes" should {
     "redirect to the new url" in {
       forAll(genIntersperseString(Gen.alphaLowerStr, "/") -> "path") { path =>
         val response = route(app, FakeRequest("GET", s"/api-hub/$path")).get
-        status(response) shouldBe MOVED_PERMANENTLY
+        status(response) shouldBe SEE_OTHER
         redirectLocation(response) shouldBe Some(s"/integration-hub/$path")
       }
     }

--- a/test/routes/OldRoutesSpec.scala
+++ b/test/routes/OldRoutesSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package routes
+
+import generators.Generators
+import org.scalacheck.Gen
+import org.scalatest.TestData
+import org.scalatestplus.play.WsScalaTestClient
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.play.guice.GuiceOneAppPerTest
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.Helpers._
+import play.api.test._
+
+import scala.language.implicitConversions
+
+class OldRoutesSpec
+  extends AnyWordSpec
+    with Matchers
+    with WsScalaTestClient
+    with GuiceOneAppPerTest
+    with Generators
+    with ScalaCheckPropertyChecks {
+
+  implicit override def newAppForTest(testData: TestData): Application =
+    new GuiceApplicationBuilder()
+      .configure(testData.configMap ++ Map("play.http.router" -> "routes.OldRoutes"))
+      .build()
+
+  "OldRoutes" should {
+    "redirect to the new url" in {
+      forAll(genIntersperseString(Gen.alphaLowerStr, "/") -> "path") { path =>
+        val response = route(app, FakeRequest("GET", s"/api-hub/$path")).get
+        status(response) shouldBe MOVED_PERMANENTLY
+        redirectLocation(response) shouldBe Some(s"/integration-hub/$path")
+      }
+    }
+  }
+}


### PR DESCRIPTION
There were some conflicts with the other routes so I went with the [health.Routes](https://github.com/hmrc/bootstrap-play/blob/main/bootstrap-health-play-30/src/main/scala/health/HealthRoutes.scala) approach