### PR TITLE
HIPP-1434: Fix some QA raised defects

### DIFF
--- a/app/controllers/application/UpdateApplicationTeamController.scala
+++ b/app/controllers/application/UpdateApplicationTeamController.scala
@@ -45,18 +45,19 @@ class UpdateApplicationTeamController @Inject()(
 
   private val form = formProvider()
 
-  def onPageLoad(applicationId: String): Action[AnyContent] = (identify andThen applicationAuth(applicationId)) async {
+  def onPageLoad(applicationId: String): Action[AnyContent] = (identify andThen applicationAuth(applicationId, includeDeleted = true)) async {
     implicit request => showView(OK, form)
   }
 
   private def showView(code: Int, form: Form[_])(implicit request: ApplicationRequest[_]): Future[Result] = {
     apiHubService.findTeams(None).map(teams => {
+      val sortedTeams = teams.sortBy(_.name.toLowerCase)
       val owningTeam = teams.find(team => request.application.teamId.contains(team.id))
-      Status(code)(view(form, request.application, owningTeam, teams, request.identifierRequest.user))
+      Status(code)(view(form, request.application, owningTeam, sortedTeams, request.identifierRequest.user))
     })
   }
 
-  def onSubmit(applicationId: String): Action[AnyContent] = (identify andThen applicationAuth(applicationId)).async {
+  def onSubmit(applicationId: String): Action[AnyContent] = (identify andThen applicationAuth(applicationId, includeDeleted = true)).async {
     implicit request =>
       form.bindFromRequest().fold(
         formWithErrors => {

--- a/test/controllers/application/UpdateApplicationTeamControllerSpec.scala
+++ b/test/controllers/application/UpdateApplicationTeamControllerSpec.scala
@@ -57,7 +57,7 @@ class UpdateApplicationTeamControllerSpec
         "must return 200 Ok and the correct view for a support user" in {
             forAll(usersWhoCanSupport) { user =>
                 val fixture = buildFixture(user)
-                when(fixture.applicationAuthActionProvider.apply(any, any, any)(any)).thenReturn(successfulApplicationAuthAction(FakeApplication))
+                when(fixture.applicationAuthActionProvider.apply(any, eqTo(false), eqTo(true))(any)).thenReturn(successfulApplicationAuthAction(FakeApplication))
                 when(fixture.apiHubService.findTeams(any)(any)).thenReturn(Future.successful(allTeams))
 
                 running(fixture.playApplication) {
@@ -76,7 +76,7 @@ class UpdateApplicationTeamControllerSpec
         "must return 200 Ok and the correct view for a non-support user who is on the API team" in {
             forAll(usersWhoCannotSupport) { user =>
                 val fixture = buildFixture(user)
-                when(fixture.applicationAuthActionProvider.apply(any, any, any)(any)).thenReturn(successfulApplicationAuthAction(FakeApplication))
+                when(fixture.applicationAuthActionProvider.apply(any, eqTo(false), eqTo(true))(any)).thenReturn(successfulApplicationAuthAction(FakeApplication))
                 when(fixture.apiHubService.findTeams(any)(any)).thenReturn(Future.successful(allTeams))
 
                 running(fixture.playApplication) {
@@ -95,7 +95,7 @@ class UpdateApplicationTeamControllerSpec
         "must redirect to Unauthorised page for a non-support user not on the api team" in {
             forAll(usersWhoCannotSupport) { user =>
                 val fixture = buildFixture(user)
-                when(fixture.applicationAuthActionProvider.apply(any, any, any)(any)).thenReturn(unauthorisedApplicationAuthAction())
+                when(fixture.applicationAuthActionProvider.apply(any, eqTo(false), eqTo(true))(any)).thenReturn(unauthorisedApplicationAuthAction())
                 when(fixture.apiHubService.findTeams(any)(any)).thenReturn(Future.successful(allTeams))
 
                 running(fixture.playApplication) {
@@ -113,7 +113,7 @@ class UpdateApplicationTeamControllerSpec
         "must return 200 Ok and the correct view for a support user when a team has been selected" in {
             forAll(usersWhoCanSupport) { user =>
                 val fixture = buildFixture(user)
-                when(fixture.applicationAuthActionProvider.apply(any, any, any)(any)).thenReturn(successfulApplicationAuthAction(FakeApplication))
+                when(fixture.applicationAuthActionProvider.apply(any, eqTo(false), eqTo(true))(any)).thenReturn(successfulApplicationAuthAction(FakeApplication))
                 when(fixture.apiHubService.findTeams(any)(any)).thenReturn(Future.successful(allTeams))
                 when(fixture.apiHubService.changeOwningTeam(any, any)(any)).thenReturn(Future.successful(Some(())))
 
@@ -135,7 +135,7 @@ class UpdateApplicationTeamControllerSpec
         "must return 400 when a team has not been selected" in {
             forAll(usersWhoCanSupport) { user =>
                 val fixture = buildFixture(user)
-                when(fixture.applicationAuthActionProvider.apply(any, any, any)(any)).thenReturn(successfulApplicationAuthAction(FakeApplication))
+                when(fixture.applicationAuthActionProvider.apply(any, eqTo(false), eqTo(true))(any)).thenReturn(successfulApplicationAuthAction(FakeApplication))
                 when(fixture.apiHubService.findTeams(any)(any)).thenReturn(Future.successful(allTeams))
                 when(fixture.apiHubService.changeOwningTeam(any, any)(any)).thenReturn(Future.successful(Some(())))
 
@@ -158,7 +158,7 @@ class UpdateApplicationTeamControllerSpec
             forAll(usersWhoCanSupport) { user =>
                 val fixture = buildFixture(user)
 
-                when(fixture.applicationAuthActionProvider.apply(any, any, any)(any)).thenReturn(successfulApplicationAuthAction(FakeApplication))
+                when(fixture.applicationAuthActionProvider.apply(any, eqTo(false), eqTo(true))(any)).thenReturn(successfulApplicationAuthAction(FakeApplication))
                 when(fixture.apiHubService.findTeams(any)(any)).thenReturn(Future.successful(allTeams))
                 when(fixture.apiHubService.changeOwningTeam(any, any)(any)).thenReturn(Future.successful(None))
 


### PR DESCRIPTION
Two acceptance criteria points failed because:
- teams were not ordered by name
- couldn't change the owning team on deleted applications