### PR TITLE
HIPP-987: Data retrieval action bindings

### DIFF
--- a/app/config/Module.scala
+++ b/app/config/Module.scala
@@ -33,6 +33,7 @@ class Module extends play.api.inject.Module {
       bindz(classOf[AddAnApiDataRetrievalAction]).to(classOf[AddAnApiDataRetrievalActionImpl]).eagerly(),
       bindz(classOf[AccessRequestDataRetrievalAction]).to(classOf[AccessRequestDataRetrievalActionImpl]).eagerly(),
       bindz(classOf[CreateTeamDataRetrievalAction]).to(classOf[CreateTeamDataRetrievalActionImpl]).eagerly(),
+      bindz(classOf[ProduceApiDataRetrievalAction]).to(classOf[ProduceApiDataRetrievalActionImpl]).eagerly(),
       bindz(classOf[DataRequiredAction]).to(classOf[DataRequiredActionImpl]).eagerly(),
       bindz[ApplicationAuthActionProvider].to(classOf[ApplicationAuthActionProviderImpl]).eagerly(),
       bindz[ApiAuthActionProvider].to(classOf[ApiAuthActionProviderImpl]).eagerly(),

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -57,6 +57,7 @@ trait SpecBase
         bind[AccessRequestDataRetrievalAction].toInstance(new FakeAccessRequestDataRetrievalAction(userAnswers)),
         bind[AddAnApiDataRetrievalAction].toInstance(new FakeAddAnApiDataRetrievalAction(userAnswers)),
         bind[CreateTeamDataRetrievalAction].toInstance(new FakeCreateTeamDataRetrievalAction(userAnswers)),
+        bind[ProduceApiDataRetrievalAction].toInstance(new FakeProduceApiDataRetrievalAction(userAnswers)),
         bind[Domains].toInstance(FakeDomains),
         bind[Hods].toInstance(FakeHods),
         bind[Platforms].toInstance(FakePlatforms)

--- a/test/controllers/actions/FakeProduceApiDataRetrievalAction.scala
+++ b/test/controllers/actions/FakeProduceApiDataRetrievalAction.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import models.UserAnswers
+import models.requests.{IdentifierRequest, OptionalDataRequest}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class FakeProduceApiDataRetrievalAction(dataToReturn: Option[UserAnswers]) extends ProduceApiDataRetrievalAction {
+
+  override protected def transform[A](request: IdentifierRequest[A]): Future[OptionalDataRequest[A]] = {
+    Future(OptionalDataRequest(request.request, request.user, dataToReturn))
+  }
+
+  override protected implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+
+}


### PR DESCRIPTION
https://jira.tools.tax.service.gov.uk/browse/HIPP-987

Missed out binding ProduceApiDataRetrievalAction to its implementation
Missed out adding FakeProduceApiDataRetrievalAction and binding it in SpecBase
Added that detail to Jira ticket
