### PR TITLE
HIPP-1568: Render not found view with logged in user

### DIFF
--- a/app/handlers/ErrorHandler.scala
+++ b/app/handlers/ErrorHandler.scala
@@ -33,7 +33,15 @@ class ErrorHandler @Inject()(
                             )(implicit val ec: ExecutionContext) extends FrontendErrorHandler with I18nSupport {
   override def standardErrorTemplate(pageTitle: String, heading: String, message: String)(implicit request: RequestHeader): Future[Html] =
     Future.successful(view(pageTitle, heading, message, requestUser()))
-    
+
+  override def notFoundTemplate(implicit request: RequestHeader): Future[Html] =
+    Future.successful(view(
+      "global.error.pageNotFound404.title",
+      "global.error.pageNotFound404.heading",
+      "global.error.pageNotFound404.message",
+      requestUser()
+    ))
+
   private def requestUser()(implicit requestHeader: RequestHeader) =
     requestHeader match {
       case r: BaseRequest[?] => r.maybeUser


### PR DESCRIPTION
@saritaparigi found that when navigating to a non existing endpoint the default error handler for **not found** errors was not considering the logged in user.
This should fix that.