### PR TITLE
HIPP-2162: Fix QA issue

### DIFF
--- a/app/controllers/myapis/produce/ProduceApiCheckYourAnswersController.scala
+++ b/app/controllers/myapis/produce/ProduceApiCheckYourAnswersController.scala
@@ -16,7 +16,7 @@
 
 package controllers.myapis.produce
 
-import config.{Domains, Hods}
+import config.{ApiStatuses, Domains, Hods}
 import controllers.actions.*
 import forms.YesNoFormProvider
 import models.api.{ApiStatus, SubDomain}
@@ -58,6 +58,7 @@ class ProduceApiCheckYourAnswersController @Inject()(
                                                       domains: Domains,
                                                       apiHubService: ApiHubService,
                                                       formProvider: YesNoFormProvider,
+                                                      apiStatuses: ApiStatuses
                                            )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport with Logging {
 
   private lazy val failureViewModel = ProduceApiDeploymentErrorViewModel(
@@ -257,7 +258,7 @@ class ProduceApiCheckYourAnswersController @Inject()(
       ProduceApiEgressPrefixesSummary.row(userAnswers),
       ProduceApiHodSummary.row(userAnswers, hods),
       ProduceApiDomainSummary.row(userAnswers, domains),
-      ProduceApiStatusSummary.row(userAnswers),
+      ProduceApiStatusSummary.row(userAnswers, apiStatuses),
       ProduceApiPassthroughSummary.row(userAnswers),
     ).flatten
 

--- a/app/controllers/myapis/update/UpdateApiCheckYourAnswersController.scala
+++ b/app/controllers/myapis/update/UpdateApiCheckYourAnswersController.scala
@@ -16,7 +16,7 @@
 
 package controllers.myapis.update
 
-import config.{Domains, Hods}
+import config.{ApiStatuses, Domains, Hods}
 import controllers.actions.*
 import controllers.helpers.ErrorResultBuilder
 import forms.YesNoFormProvider
@@ -60,6 +60,7 @@ class UpdateApiCheckYourAnswersController @Inject()(
                                                       apiHubService: ApiHubService,
                                                       errorResultBuilder: ErrorResultBuilder,
                                                       formProvider: YesNoFormProvider,
+                                                      apiStatuses: ApiStatuses
                                                     )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport with Logging {
 
   private lazy val errorViewModel = ProduceApiDeploymentErrorViewModel(
@@ -242,7 +243,7 @@ class UpdateApiCheckYourAnswersController @Inject()(
       UpdateApiEgressPrefixesSummary.row(userAnswers),
       UpdateApiHodSummary.row(userAnswers, hods),
       UpdateApiDomainSummary.row(userAnswers, domains),
-      UpdateApiStatusSummary.row(userAnswers, userModel),
+      UpdateApiStatusSummary.row(userAnswers, userModel, apiStatuses),
     ).flatten
   
   private def buildView(form: Form[?])(implicit request: DataRequest[AnyContent]) = {

--- a/app/viewmodels/checkAnswers/myapis/produce/ProduceApiStatusSummary.scala
+++ b/app/viewmodels/checkAnswers/myapis/produce/ProduceApiStatusSummary.scala
@@ -16,11 +16,11 @@
 
 package viewmodels.checkAnswers.myapis.produce
 
+import config.ApiStatuses
 import controllers.myapis.produce.routes
 import models.{CheckMode, UserAnswers}
 import pages.myapis.produce.ProduceApiStatusPage
 import play.api.i18n.Messages
-import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist._
@@ -28,12 +28,11 @@ import viewmodels.implicits._
 
 object ProduceApiStatusSummary  {
 
-  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+  def row(answers: UserAnswers, apiStatuses: ApiStatuses)(implicit messages: Messages): Option[SummaryListRow] =
     answers.get(ProduceApiStatusPage).map {
-      answer =>
-
+      apiStatus =>
         val value = ValueViewModel(
-          HtmlContent(answer.toString)
+          HtmlContent(apiStatuses.description(apiStatus))
         )
 
         SummaryListRowViewModel(

--- a/app/viewmodels/checkAnswers/myapis/update/UpdateApiStatusSummary.scala
+++ b/app/viewmodels/checkAnswers/myapis/update/UpdateApiStatusSummary.scala
@@ -16,6 +16,7 @@
 
 package viewmodels.checkAnswers.myapis.update
 
+import config.ApiStatuses
 import controllers.myapis.update.routes
 import models.user.UserModel
 import models.{CheckMode, UserAnswers}
@@ -28,11 +29,11 @@ import viewmodels.implicits.*
 
 object UpdateApiStatusSummary  {
 
-  def row(answers: UserAnswers, user: UserModel)(implicit messages: Messages): Option[SummaryListRow] =
+  def row(answers: UserAnswers, user: UserModel, apiStatuses: ApiStatuses)(implicit messages: Messages): Option[SummaryListRow] =
       answers.get(UpdateApiStatusPage).filter(_ => user.permissions.canSupport).map {
-        answer =>
+        apiStatus =>
           val value = ValueViewModel(
-            HtmlContent(answer.toString)
+            HtmlContent(apiStatuses.description(apiStatus))
           )
 
           SummaryListRowViewModel(

--- a/test/controllers/myapis/update/UpdateApiCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/myapis/update/UpdateApiCheckYourAnswersControllerSpec.scala
@@ -17,6 +17,7 @@
 package controllers.myapis.update
 
 import base.SpecBase
+import config.ApiStatuses
 import controllers.actions.{FakeApiDetail, FakeSupporter, FakeUser}
 import controllers.myapis.update.routes as updateApiRoutes
 import controllers.routes
@@ -25,7 +26,6 @@ import forms.YesNoFormProvider
 import models.api.Alpha
 import models.deployment.*
 import models.myapis.produce.*
-import models.team.Team
 import models.user.{Permissions, UserModel}
 import models.{CheckMode, UserAnswers}
 import org.mockito.ArgumentMatchers.any
@@ -39,17 +39,16 @@ import play.api.i18n.Messages
 import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
-import repositories.{SessionRepository, UpdateApiSessionRepository}
+import repositories.UpdateApiSessionRepository
 import services.ApiHubService
 import viewmodels.checkAnswers.myapis.update.*
 import viewmodels.govuk.all.SummaryListViewModel
 import viewmodels.myapis.{DeploymentSuccessViewModel, produce}
-import viewmodels.myapis.produce.{ProduceApiCheckYourAnswersViewModel, ProduceApiDeploymentErrorViewModel}
+import viewmodels.myapis.produce.ProduceApiCheckYourAnswersViewModel
 import views.html.ErrorTemplate
 import views.html.myapis.DeploymentSuccessView
 import views.html.myapis.produce.{ProduceApiCheckYourAnswersView, ProduceApiDeploymentErrorView}
 
-import java.time.LocalDateTime
 import scala.concurrent.Future
 
 class UpdateApiCheckYourAnswersControllerSpec extends SpecBase with MockitoSugar with TableDrivenPropertyChecks {
@@ -117,7 +116,7 @@ class UpdateApiCheckYourAnswersControllerSpec extends SpecBase with MockitoSugar
           controllers.myapis.update.routes.UpdateApiCheckYourAnswersController.onSubmit()
         )
         val view = fixture.application.injector.instanceOf[ProduceApiCheckYourAnswersView]
-        val expectedSummaryList = summaryList().copy(rows = summaryList().rows :+ UpdateApiStatusSummary.row(fullyPopulatedUserAnswers, FakeSupporter).get)
+        val expectedSummaryList = summaryList().copy(rows = summaryList().rows :+ UpdateApiStatusSummary.row(fullyPopulatedUserAnswers, FakeSupporter, fixture.apiStatuses).get)
         
         status(result) mustEqual OK
 
@@ -315,7 +314,8 @@ class UpdateApiCheckYourAnswersControllerSpec extends SpecBase with MockitoSugar
   private case class Fixture(
                               application: PlayApplication,
                               apiHubService: ApiHubService,
-                              sessionRepository: UpdateApiSessionRepository
+                              sessionRepository: UpdateApiSessionRepository,
+                              apiStatuses: ApiStatuses
                             )
 
   private def buildFixture(userAnswers: Option[UserAnswers], userModel: Option[UserModel] = None): Fixture = {
@@ -327,6 +327,7 @@ class UpdateApiCheckYourAnswersControllerSpec extends SpecBase with MockitoSugar
         bind[UpdateApiSessionRepository].toInstance(sessionRepository)
       )
       .build()
-    Fixture(playApplication, apiHubService, sessionRepository)
+    val apiStatuses = playApplication.injector.instanceOf[ApiStatuses]
+    Fixture(playApplication, apiHubService, sessionRepository, apiStatuses)
   }
 }


### PR DESCRIPTION
The API status on the produce/update CYA page still used the old ALPHA etc value